### PR TITLE
Reduce ram usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ pub fn main() {
         // Generating mipmaps takes a minute
         .insert_resource(MipmapGeneratorSettings {
             anisotropic_filtering: 16,
+            max_parallelism: 8,
             ..default()
         })
         .add_plugins((

--- a/src/mipmap_generator.rs
+++ b/src/mipmap_generator.rs
@@ -25,6 +25,7 @@ pub struct MipmapGeneratorSettings {
     pub anisotropic_filtering: u16,
     pub filter_type: FilterType,
     pub minimum_mip_resolution: u32,
+    pub max_parallelism: usize,
 }
 
 ///Mipmaps will not be generated for materials found on entities that also have the `NoMipmapGeneration` component.
@@ -38,6 +39,7 @@ impl Default for MipmapGeneratorSettings {
             anisotropic_filtering: 8,
             filter_type: FilterType::Triangle,
             minimum_mip_resolution: 1,
+            max_parallelism: usize::MAX,
         }
     }
 }
@@ -95,6 +97,9 @@ pub fn generate_mipmaps<M: Material + GetImages>(
             for image_h in material.get_images().into_iter() {
                 if tasks.contains_key(image_h) {
                     continue; //There is already a task for this image
+                }
+                if tasks.len() > settings.max_parallelism {
+                    break; // Enough threads are running currently, let's continue in another frame
                 }
                 if let Some(image) = images.get_mut(image_h) {
                     let mut descriptor = match image.sampler.clone() {


### PR DESCRIPTION
Reduce RAM usage by reducing number of image copies kept in memory and by limiting parallelism to 8.
If I understand correctly now we have ~3~ 2 image data copies in RAM at the peak during mip-maps generation (original Bevy asset, `DynamicImage` being processed, ~result image data~). Previously it was 4 because of additional `clone()`.
It didn't fix loading the scene for me so I tried to reduce parallelism (I have CPU capable of processing 20 threads so I guess this number must be multiplied by number of image copies per task to get peak usage). With 8 threads it reaches 100% for me (16 GB RAM system) but it's not killed and loads properly.
If you like those changes I can prepare similar PR to `bevy_mod_mipmap_generator`.
Edit: I managed to get rid of another copy. Now there should be just 2 and it is impossible get it lower unless we break rendering for the time of mipmap generation.